### PR TITLE
Navigation Positioning fixed

### DIFF
--- a/dist/stylesheets/superslides.css
+++ b/dist/stylesheets/superslides.css
@@ -74,14 +74,13 @@ body {
 }
 
 .slides-navigation {
-  width: 85%;
   margin: 0 auto;
   position: relative;
   z-index: 3;
   top: -50%;
 }
 .slides-navigation a {
-  position: fixed;
+  position: absolute;
   display: block;
   color: black;
   background: white;

--- a/scss/superslides.scss
+++ b/scss/superslides.scss
@@ -69,13 +69,12 @@ body {
 }
 
 .slides-navigation {
-  width: 85%;
   margin: 0 auto;
   position: relative;
   z-index: 3;
   top: -50%;
   a {
-    position: fixed;
+    position: absolute;
     display: block;
     color: black;
     background: white;


### PR DESCRIPTION
Navigation controls showed up in Internet Explorer and Chrome when placed under a div. A minor tweak fixed it. 
