### PR TITLE
Fix fade animation for transparent png's

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -44,9 +44,14 @@ var fx = {
 
     $target.css({
       left: this.width,
-      opacity: 1,
+      opacity: 0,
       display: 'block'
-    });
+    }).animate({
+          opacity: 1
+        },
+        that.options.animation_speed,
+        that.options.animation_easing
+    );
 
     if (orientation.outgoing_slide >= 0) {
       $outgoing.animate({


### PR DESCRIPTION
Hello.

You can see difference here:
1. Fade effect before: http://www.falsecode.ru/blog/demos/superslides/examples/my/fade.html
2. Fade effect after: http://www.falsecode.ru/blog/demos/superslides/examples/my/myfade.html
