### PR TITLE
Min Size

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -11,6 +11,8 @@ Superslides = function(el, options) {
     pagination: true,
     hashchange: false,
     scrollable: true,
+    min_width:0,
+    min_height:0,
     elements: {
       preserve: '.preserve',
       nav: '.slides-navigation',

--- a/src/setup.js
+++ b/src/setup.js
@@ -30,8 +30,8 @@
       setTimeout(function() {
         var $children = that.$container.children();
 
-        that.width  = that._findWidth();
-        that.height = that._findHeight();
+        that.width  = Math.max(that.options.min_width, that._findWidth());
+        that.height = Math.max(that.options.min_height, that._findHeight());
 
         $children.css({
           width: that.width,


### PR DESCRIPTION
New feature added.

The slider now can be reconfigured to shrink to a minimal size which can be specified throw the 2 new parameters min_height and min_width which are set in 0 by default meaning no restriction.

When the window resizes, if any of those parameters are set, the script calculate the maximum between the new window size and the values to change the slider size.
