### PR TITLE
To fix empty page with single slide

### DIFF
--- a/dist/jquery.superslides.js
+++ b/dist/jquery.superslides.js
@@ -607,6 +607,7 @@ Superslides.prototype = {
       }
     }
     if (that.size() === 1) {
+      that.options.play             = 0;
       orientation.upcoming_slide    = 0;
       orientation.outgoing_slide    = -1;
     }

--- a/dist/jquery.superslides.js
+++ b/dist/jquery.superslides.js
@@ -606,7 +606,10 @@ Superslides.prototype = {
         window.location.hash = hash;
       }
     }
-
+    if (that.size() === 1) {
+      orientation.upcoming_slide    = 0;
+      orientation.outgoing_slide    = -1;
+    }
     that.$el.trigger('animating.slides', [orientation]);
 
     that.animation(orientation, function() {

--- a/dist/jquery.superslides.js
+++ b/dist/jquery.superslides.js
@@ -607,7 +607,9 @@ Superslides.prototype = {
       }
     }
     if (that.size() === 1) {
-      that.options.play             = 0;
+      that.stop();
+      that.options.play = 0;
+      that.options.animation_speed = 0;
       orientation.upcoming_slide    = 0;
       orientation.outgoing_slide    = -1;
     }


### PR DESCRIPTION
If slider has only one slide, prev/next buttons and keyboard arrow keys still navigate and cause an empty slide to display. This fix checks if slider has single slide or not and sets upcoming slide and outgoing slide properly.
