### PR TITLE
Reset autoplay timeout after user-initiated animation

### DIFF
--- a/src/core_prototype.js
+++ b/src/core_prototype.js
@@ -100,7 +100,7 @@ Superslides.prototype = {
   },
 
   stop: function() {
-    clearInterval(this.play_id);
+    clearTimeout(this.play_id);
     delete this.play_id;
 
     this.$el.trigger('stopped.slides');
@@ -113,16 +113,6 @@ Superslides.prototype = {
       $(window).trigger('hashchange');
     } else {
       this.animate();
-    }
-
-    if (this.options.play) {
-      if (this.play_id) {
-        this.stop();
-      }
-
-      this.play_id = setInterval(function() {
-        that.animate();
-      }, this.options.play);
     }
 
     this.$el.trigger('started.slides');
@@ -179,6 +169,14 @@ Superslides.prototype = {
 
       if (typeof userCallback === 'function') {
         userCallback();
+      }
+
+      if (that.options.play) {
+        clearTimeout(that.play_id);
+
+        that.play_id = setTimeout(function() {
+          that.animate();
+        }, that.options.play);
       }
 
       that.animating = false;

--- a/test/superslides_test.js
+++ b/test/superslides_test.js
@@ -187,15 +187,17 @@
     $slides.superslides();
   });
 
-  asyncTest('.start() should assign play_id', function() {
+  asyncTest('.animate() should assign play_id', function() {
     $slides.superslides({
       play: true
     });
 
-    setTimeout(function() {
+    $slides.on('animated.slides', function() {
       ok($slides.data('superslides').play_id);
+
+      $slides.off('animated.slides');
       start();
-    }, 100);
+    });
   });
 
   test('.stop() should remove play_id', function() {
@@ -253,6 +255,66 @@
     });
 
     $slides.superslides();
+  });
+
+  module('API Options');
+
+  asyncTest('Autoplay option should automatically switch slides user initiated after timeout', function() {
+    addSlide(1);
+    var lastAnimation;
+
+    $slides.on('animated.slides', function() {
+      var s = $slides.data('superslides');
+
+      if (s.current === 1) {
+        ok((new Date() - lastAnimation) >= (s.options.play + s.options.animation_speed));
+
+        $slides.off('animated.slides');
+        start();
+      }
+
+      lastAnimation = new Date();
+    });
+
+    $slides.superslides({
+      animation_speed: 10,
+      play: 50
+    });
+  });
+
+  asyncTest('Autoplay timeout should be reset after animation', 2, function() {
+    addSlide(2);
+    var lastAnimation;
+
+    $slides.on('animated.slides', function() {
+      var s = $slides.data('superslides');
+
+      if (s.current === 1) {
+        // Making sure that the first animation triggered upon user action.
+        ok((new Date() - lastAnimation) >= (150 + s.options.animation_speed));
+      } else if (s.current === 2) {
+        // Making sure that the last animation was triggered after the play
+        // timeout has expired.
+        ok((new Date() - lastAnimation) >= (s.options.play + s.options.animation_speed));
+
+        $slides.off('animated.slides');
+
+        start();
+      }
+
+      lastAnimation = new Date();
+    });
+
+    $slides.on('init.slides', function() {
+      setTimeout(function() {
+        $slides.superslides('animate');
+      }, 150);
+    });
+
+    $slides.superslides({
+      animation_speed: 10,
+      play: 300
+    });
   });
 
 }(jQuery));


### PR DESCRIPTION
Fixes an unexpected autoplay behavior: when the slider was animated by an external action (e.g. pagination click) right before the autoplay timeout has expired, slider would run both initiated and scheduled animations. I believe something similar is being described in #169.

The solution is to schedule the next autoplay after the current animation finishes.
