### PR TITLE
Consider only anchor tags as pagination items

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -2,7 +2,7 @@ var pagination = {
   _setCurrent: function(i) {
     if (!that.$pagination) { return; }
 
-    var $pagination_children = that.$pagination.children();
+    var $pagination_children = that.$pagination.children('a');
 
     $pagination_children.removeClass('current');
     $pagination_children.eq(i)


### PR DESCRIPTION
Due to additional elements (created for example by PIE css3 on IE8) the "current" class isn't set correctly on pagination children items
