### PR TITLE
Added semicolons + code enhancements to fix jshint warnings

### DIFF
--- a/src/core_prototype.js
+++ b/src/core_prototype.js
@@ -97,7 +97,7 @@ Superslides.prototype = {
     this.css.containers();
     this.css.images();
 
-    this.pagination._addItem(this.size())
+    this.pagination._addItem(this.size());
 
     this._findPositions(this.current);
     this.$el.trigger('updated.slides');

--- a/src/css.js
+++ b/src/css.js
@@ -49,7 +49,7 @@ var css = {
   },
   images: function() {
     var $images = that.$container.find('img')
-                                 .not(that.options.elements.preserve)
+                                 .not(that.options.elements.preserve);
 
     $images.removeAttr('width').removeAttr('height')
       .css({
@@ -116,4 +116,4 @@ var css = {
     });
 
   }
-}
+};

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -17,7 +17,8 @@ $.fn[plugin] = function(option, args) {
     if (typeof option === "string") {
       result = data[option];
       if (typeof result === 'function') {
-        return result = result.call(data, args);
+        result = result.call(data, args);
+        return result;
       }
     }
   });


### PR DESCRIPTION
When validating the `dist/jquery.superslides.js` via http://jshint.com there are 4 warnings:

```
 148    Missing semicolon.
 215    Missing semicolon.
 531    Missing semicolon.
 656    Did you mean to return a conditional instead of an assignment?
```
