### PR TITLE
Added event on slides visible

### DIFF
--- a/src/core_prototype.js
+++ b/src/core_prototype.js
@@ -192,6 +192,7 @@ Superslides.prototype = {
         that.$el.trigger('init.slides');
         that.init = true;
         that.$container.fadeIn('fast');
+	that.$el.trigger('visible.slides');
       }
     });
   }


### PR DESCRIPTION
Added an event when the first slide becomes visible after init. This can be used to do any UI manipulation that depends on the contents of the slide (ex: measure the slide content height).
