### PR TITLE
Fade-in effect for first slide is now optional

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -6,6 +6,7 @@ Superslides = function(el, options) {
     animation_speed: 600,
     animation_easing: 'swing',
     animation: 'slide',
+    fade_in_first_slide: true,
     inherit_width_from: window,
     inherit_height_from: window,
     pagination: true,

--- a/src/core_prototype.js
+++ b/src/core_prototype.js
@@ -191,7 +191,11 @@ Superslides.prototype = {
       if (!that.init) {
         that.$el.trigger('init.slides');
         that.init = true;
-        that.$container.fadeIn('fast');
+        if(that.options.fade_in_first_slide) {
+          that.$container.fadeIn('fast');
+        } else {
+          that.$container.show();
+        }
       }
     });
   }


### PR DESCRIPTION
Added new option: fade_in_first_slide
This makes the fading in effect of the first slide optional
